### PR TITLE
Fixed missing CSP meta tag

### DIFF
--- a/content/_layouts/header.html
+++ b/content/_layouts/header.html
@@ -6,6 +6,7 @@
     <meta name="title" content="@meta(title, '@config(site.name)')">
     <meta name="description" content="@meta(description, '@config(site.description)')">
     <meta name="keywords" content="Walshy, WalshyDev, Daniel, Walsh, Daniel Walsh, personal, site, blog, projects" />
+    <meta http-equiv="Content-Security-Policy" content="default-src *; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://cdnjs.cloudflare.com ">
     <meta name="author" content="Walshy" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 


### PR DESCRIPTION
Upon loading the page, the following error was caught and main.js was getting blocked. I found this while exploring the site and trying to click on the 'Light Theme' button which didn't do anything. 

"Refused to execute inline event handler because it violates the following Content Security Policy directive: "script-src 'self' https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.6.0/highlight.min.js https://static.cloudflareinsights.com/beacon.min.js". Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution. Note that hashes do not apply to event handlers, style attributes and javascript: navigations unless the 'unsafe-hashes' keyword is present."

This was caused due to a missing CSP meta tag, I've gone ahead and added it.